### PR TITLE
Django 4.2 Upgrade

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.pyc
 .tox/
 MANIFEST
+.python-version

--- a/docs/overview.txt
+++ b/docs/overview.txt
@@ -774,19 +774,19 @@ Example usage
 The following sample URLconf demonstrates using this generic view to
 list items of a particular model class which have a given tag::
 
-   from django.conf.urls.defaults import *
+   from django.urls import re_path
 
    from tagging.views import tagged_object_list
 
    from shop.apps.products.models import Widget
 
-   urlpatterns = patterns('',
-       url(r'^widgets/tag/(?P<tag>[^/]+)/$',
+   urlpatterns = [
+       re_path(r'^widgets/tag/(?P<tag>[^/]+)/$',
            tagged_object_list,
            dict(queryset_or_model=Widget, paginate_by=10, allow_empty=True,
                 template_object_name='widget'),
            name='widget_tag_detail'),
-   )
+   ]
 
 The following sample view demonstrates wrapping this generic view to
 perform filtering of the objects which are listed::

--- a/tagging/__init__.py
+++ b/tagging/__init__.py
@@ -1,4 +1,4 @@
-VERSION = (0, 4, 1, 'dev', 1)
+VERSION = (0, 4, 2, 'dev', 1)
 
 
 

--- a/tagging/fields.py
+++ b/tagging/fields.py
@@ -4,7 +4,7 @@ A custom Model Field for tagging.
 from django.conf import settings
 from django.db.models import signals
 from django.db.models.fields import CharField
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from tagging.settings import DEFAULT_FORCE_LOWERCASE_TAGS
 from tagging.models import Tag

--- a/tagging/forms.py
+++ b/tagging/forms.py
@@ -3,7 +3,7 @@ Tagging components for Django's form library.
 """
 from django import forms
 from django.conf import settings
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 
 from tagging.models import Tag
 from tagging.settings import DEFAULT_MAX_TAG_LENGTH

--- a/tagging/models.py
+++ b/tagging/models.py
@@ -169,7 +169,14 @@ class TagManager(models.Manager):
             # Django 1.2+
             compiler = queryset.query.get_compiler(using='default')
             if getattr(compiler, 'compile', None):
-                where, params = compiler.compile(queryset.query.where)
+                # Check if queryset has any WHERE conditions
+                if queryset.query.where.children:
+                    where, params = compiler.compile(queryset.query.where)
+                else:
+                    # Empty WHERE clause.
+                    # Do not compile or exception thrown for Django 4.2.
+                    where = ''
+                    params = []
             else:
                 where, params = queryset.query.where.as_sql(
                     compiler.quote_name_unless_alias, compiler.connection

--- a/tagging/models.py
+++ b/tagging/models.py
@@ -143,9 +143,9 @@ class TagManager(models.Manager):
         """
         if filters is None: filters = {}
 
-        queryset = model._default_manager.filter()
-        for f in filters.items():
-            queryset.query.add_filter(f)
+        queryset = model._default_manager.all()
+        if filters:
+            queryset = queryset.filter(**filters)
         usage = self.usage_for_queryset(queryset, counts, min_count)
 
         return usage

--- a/tagging/models.py
+++ b/tagging/models.py
@@ -141,7 +141,8 @@ class TagManager(models.Manager):
         of field lookups to be applied to the given Model as the
         ``filters`` argument.
         """
-        if filters is None: filters = {}
+        if filters is None:
+            filters = {}
 
         queryset = model._default_manager.all()
         if filters:

--- a/tagging/models.py
+++ b/tagging/models.py
@@ -7,7 +7,7 @@ from django.contrib.contenttypes.models import ContentType
 from django.conf import settings
 
 from django.db import connection, models
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from tagging.settings import DEFAULT_FORCE_LOWERCASE_TAGS
 from tagging.utils import (

--- a/tagging/templatetags/tagging_tags.py
+++ b/tagging/templatetags/tagging_tags.py
@@ -1,6 +1,6 @@
 from django.apps import apps
 from django.template import Library, Node, TemplateSyntaxError, Variable
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 
 from tagging.models import Tag, TaggedItem
 from tagging.utils import LINEAR, LOGARITHMIC

--- a/tagging/utils.py
+++ b/tagging/utils.py
@@ -8,7 +8,7 @@ from django.db.models.query import QuerySet
 try:
     from django.utils.encoding import force_unicode
 except ImportError:
-    from django.utils.encoding import force_text as force_unicode
+    from django.utils.encoding import force_str as force_unicode
 from django.utils.translation import gettext as _
 
 try:

--- a/tagging/utils.py
+++ b/tagging/utils.py
@@ -9,7 +9,7 @@ try:
     from django.utils.encoding import force_unicode
 except ImportError:
     from django.utils.encoding import force_text as force_unicode
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 
 try:
     basestring

--- a/tagging/views.py
+++ b/tagging/views.py
@@ -2,7 +2,7 @@
 Tagging related views.
 """
 from django.http import Http404
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 from django.views.generic.list_detail import object_list
 
 from tagging.models import Tag, TaggedItem

--- a/tox.ini
+++ b/tox.ini
@@ -5,12 +5,18 @@
 
 [tox]
 envlist =
-    py27-django111
-    py37-django{111,22}
+    py37-django2.2
+    py{38,39}-django{30,31,32,40,41,42}
 
 [testenv]
 commands = django-admin.py test --settings=tagging.tests.settings
 deps =
     django-nose
-    django111: Django>=1.11, <1.12
-    django22: Django>=2.2, < 2.3
+    django2.2: Django>=2.2, <2.3
+    django30: Django>=3.0, <3.1
+    django31: Django>=3.1, <3.2
+    django32: Django>=3.2, <3.3
+    django40: Django>=4.0, <4.1
+    django41: Django>=4.1, <4.2
+    django42: Django>=4.2, <4.3
+

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@
 
 [tox]
 envlist =
-    py37-django2.2
+    py37-django22
     py{38,39}-django{30,31,32,40,41,42}
 
 [testenv]
@@ -13,7 +13,7 @@ commands = django-admin test --settings=tagging.tests.settings
 
 deps =
     django-nose
-    django2.2: Django>=2.2, <2.3
+    django22: Django>=2.2, <2.3
     django30: Django>=3.0, <3.1
     django31: Django>=3.1, <3.2
     django32: Django>=3.2, <3.3

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,8 @@ envlist =
     py{38,39}-django{30,31,32,40,41,42}
 
 [testenv]
-commands = django-admin.py test --settings=tagging.tests.settings
+commands = django-admin test --settings=tagging.tests.settings
+
 deps =
     django-nose
     django2.2: Django>=2.2, <2.3


### PR DESCRIPTION
Compatibility fixes for Django 4.2

## Django 4.0.10
* [Django 4.0 deprecations](https://docs.djangoproject.com/en/5.0/internals/deprecation/#deprecation-removed-in-4-0):
* See the [Django 3.0 release notes](https://docs.djangoproject.com/en/5.0/releases/3.0/#deprecated-features-3-0) for more details on these changes.

- [x] **django.utils.encoding.force_text()** and **smart_text()** will be removed.  The aliases are  force_str() and smart_str().
- [x] **django.utils.http.urlquote()**, **urlquote_plus()**, **urlunquote()**, and **urlunquote_plus()** will be removed.
- [x] **django.utils.translation.ugettext()**, **ugettext_lazy()**, **ugettext_noop()**, **ungettext()**, and **ungettext_lazy()** will be removed.
- [x] **django.views.i18n.set_language()** will no longer set the user language in **request.session** (key **django.utils.translation.LANGUAGE_SESSION_KEY**). 
- [x] **alias=None** will be required in the signature of **django.db.models.Expression.get_group_by_cols()** subclasses.
- [x] **django.utils.text.unescape_entities()** will be removed.
- [x] **django.utils.http.is_safe_url()** will be removed.

* See the [Django 3.1 release notes](https://docs.djangoproject.com/en/5.0/releases/3.1/#deprecated-features-3-1) for more details on these changes.
- [x] **The PASSWORD_RESET_TIMEOUT_DAYS** setting will be removed.
- [x] The undocumented usage of the **isnull** lookup with non-boolean values as the right-hand side will no longer be allowed.
- [x] The **django.db.models.query_utils.InvalidQuery** exception class will be removed.
- [x] The **django-admin.py** entry point will be removed.
- [x] Support for the pre-Django 3.1 encoding format of cookies values used by **django.contrib.messages.storage.cookie.CookieStorage** will be removed.
- [x] The **providing_args** argument for **django.dispatch.Signal** will be removed.
- [x] The **length** argument for **django.utils.crypto.get_random_string()** will be required.
- [x] The model **NullBooleanField** will be removed. A stub field will remain for compatibility with historical migrations. 
- [x] The model **django.contrib.postgres.fields.JSONField** will be removed. A stub field will remain for compatibility with historical migrations.
- [x] **django.contrib.postgres.forms.JSONField**, **django.contrib.postgres.fields.jsonb.KeyTransform**, and **django.contrib.postgres.fields.jsonb.KeyTextTransform** will be removed.
- [x] The **DEFAULT_HASHING_ALGORITHM** transitional setting will be removed.
- [x] Support for passing raw column aliases to **QuerySet.order_by()** will be removed.
- [x] **django.conf.urls.url()** will be removed.  It's an alias of **django.urls.re_path()**.
- [x] The **get_response** argument for **django.utils.deprecation.MiddlewareMixin.__init__()** will be required and won’t accept **None**.
- [x] The **list** message for **ModelMultipleChoiceField** will be removed.
- [x] The **HttpRequest.is_ajax()** method will be removed.
- [x] The **{% ifequal %}** and **{% ifnotequal %}** template tags will be removed.

### pre-Django 3.1 SHA-1
- [x] Support for the pre-Django 3.1 password reset tokens in the admin site (that use the SHA-1 hashing algorithm) will be removed.
- [x] Support for the pre-Django 3.1 encoding format of sessions will be removed.
- [x] Support for the pre-Django 3.1 **django.core.signing.Signer** signatures (encoded with the SHA-1 algorithm) will be removed.
- [x] Support for the pre-Django 3.1 **django.core.signing.dumps()** signatures (encoded with the SHA-1 algorithm) in **django.core.signing.loads()** will be removed.
- [x] Support for the pre-Django 3.1 user sessions (that use the SHA-1 algorithm) will be removed.

## Django 4.1.13
See the [Django 3.2 release notes](https://docs.djangoproject.com/en/5.0/releases/3.2/#deprecated-features-3-2) for more details on these changes.

- [x] Support for assigning objects which don’t support creating deep copies with **copy.deepcopy()** to class attributes in **TestCase.setUpTestData()** will be removed.
- [x] The **whitelist** argument and **domain_whitelist** attribute of **django.core.validators.EmailValidator** will be removed.
- [x] **TransactionTestCase.assertQuerysetEqual()** will no longer automatically call **repr()** on a queryset when compared to string values.
- [x] Support for the pre-Django 3.2 format of messages used by **django.contrib.messages.storage.cookie.CookieStorage** will be removed.
- [x] **BaseCommand.requires_system_checks** won’t support boolean values. Use '__all__' instead of True, and [] (an empty list) instead of False.
- [x] **django.core.cache.backends.memcached.MemcachedCache** will be removed.
- [x] The **default_app_config** module variable will be removed. 


# Other required fixes
- [x] Implement fix for how filters are applied in Django 4.2.
- [x] Implement fix for empty WHERE clause throwing exception in Django 4.2
- [x] Fix `django-admin.py` entry point within `tox.ini` (_not compatible with Django 4.2_) 

# Test Environment Updates
- [x] Update `tox.ini` to test for Django 2.2+
